### PR TITLE
DestinationRule for circuit breaking

### DIFF
--- a/samples/httpbin/istio-manifests/destination-rule.yaml
+++ b/samples/httpbin/istio-manifests/destination-rule.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: httpbin
+spec:
+  host: httpbin
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 1
+      http:
+        http1MaxPendingRequests: 1
+        maxRequestsPerConnection: 1
+    outlierDetection:
+      consecutive5xxErrors: 1
+      interval: 1s
+      baseEjectionTime: 3m
+      maxEjectionPercent: 100


### PR DESCRIPTION
https://istio.io/latest/docs/tasks/traffic-management/circuit-breaking/

```sh
❯ kubectl exec "$FORTIO_POD" -c fortio -- /usr/bin/fortio load -c 2 -qps 0 -n 20 -loglevel Warning http://httpbin:8000/get
{"ts":1738033118.284908,"level":"info","r":1,"file":"logger.go","line":290,"msg":"Log level is now 3 Warning (was 2 Info)"}
Fortio 1.66.5 running at 0 queries per second, 2->2 procs, for 20 calls: http://httpbin:8000/get
Starting at max qps with 2 thread(s) [gomax 2] for exactly 20 calls (10 per thread + 0)
{"ts":1738033118.295915,"level":"warn","r":6,"file":"http_client.go","line":1151,"msg":"Non ok http code","code":503,"status":"HTTP/1.1 503","thread":0,"run":0}
{"ts":1738033118.298641,"level":"warn","r":6,"file":"http_client.go","line":1151,"msg":"Non ok http code","code":503,"status":"HTTP/1.1 503","thread":0,"run":0}
{"ts":1738033118.302764,"level":"warn","r":7,"file":"http_client.go","line":1151,"msg":"Non ok http code","code":503,"status":"HTTP/1.1 503","thread":1,"run":0}
{"ts":1738033118.326543,"level":"warn","r":7,"file":"http_client.go","line":1151,"msg":"Non ok http code","code":503,"status":"HTTP/1.1 503","thread":1,"run":0}
{"ts":1738033118.334946,"level":"warn","r":7,"file":"http_client.go","line":1151,"msg":"Non ok http code","code":503,"status":"HTTP/1.1 503","thread":1,"run":0}
Ended after 58.05797ms : 20 calls. qps=344.48
Aggregated Function Time : count 20 avg 0.0052897992 +/- 0.002482 min 0.000762463 max 0.008263353 sum 0.105795984
# range, mid point, percentile, count
>= 0.000762463 <= 0.001 , 0.000881232 , 15.00, 3
> 0.001 <= 0.002 , 0.0015 , 20.00, 1
> 0.002 <= 0.003 , 0.0025 , 25.00, 1
> 0.004 <= 0.005 , 0.0045 , 30.00, 1
> 0.005 <= 0.006 , 0.0055 , 55.00, 5
> 0.006 <= 0.007 , 0.0065 , 75.00, 4
> 0.007 <= 0.008 , 0.0075 , 80.00, 1
> 0.008 <= 0.00826335 , 0.00813168 , 100.00, 4
# target 50% 0.0058
# target 75% 0.007
# target 90% 0.00813168
# target 99% 0.00825019
# target 99.9% 0.00826204
Error cases : count 5 avg 0.001436173 +/- 0.0007759 min 0.000762463 max 0.002725754 sum 0.007180865
# range, mid point, percentile, count
>= 0.000762463 <= 0.001 , 0.000881232 , 60.00, 3
> 0.001 <= 0.002 , 0.0015 , 80.00, 1
> 0.002 <= 0.00272575 , 0.00236288 , 100.00, 1
# target 50% 0.000940616
# target 75% 0.00175
# target 90% 0.00236288
# target 99% 0.00268947
# target 99.9% 0.00272213
# Socket and IP used for each connection:
[0]   3 socket used, resolved to 34.118.227.112:8000, connection timing : count 3 avg 0.00013324 +/- 6.086e-06 min 0.000126591 max 0.000141298 sum 0.00039972
[1]   4 socket used, resolved to 34.118.227.112:8000, connection timing : count 4 avg 0.0001824155 +/- 3.682e-05 min 0.000142142 max 0.000238079 sum 0.000729662
Connection time (s) : count 7 avg 0.00016134029 +/- 3.719e-05 min 0.000126591 max 0.000238079 sum 0.001129382
Sockets used: 7 (for perfect keepalive, would be 2)
Uniform: false, Jitter: false, Catchup allowed: true
IP addresses distribution:
34.118.227.112:8000: 7
Code 200 : 15 (75.0 %)
Code 503 : 5 (25.0 %)
Response Header Sizes : count 20 avg 183.75 +/- 106.1 min 0 max 245 sum 3675
Response Body/Total Sizes : count 20 avg 790.75 +/- 317.4 min 241 max 974 sum 15815
All done 20 calls (plus 0 warmup) 5.290 ms avg, 344.5 qps

❯ kubectl exec "$FORTIO_POD" -c fortio -- /usr/bin/fortio load -c 3 -qps 0 -n 30 -loglevel Warning http://httpbin:8000/get
Code 200 : 13 (43.3 %)
Code 503 : 17 (56.7 %)
```